### PR TITLE
feat: use wasm-opt to decrease forwarder contract size

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -12,6 +12,7 @@ FEES_WASM_FILE = "aurora-forward-fees.wasm"
 dependencies = [
     "build-contracts",
     "cp-contracts",
+    "optimize-contracts",
     "build-factory",
     "cp-factory",
     "contract-stats"
@@ -29,6 +30,8 @@ args = [
     "--all-targets"
 ]
 
+[tasks.test]
+alias = "tests"
 
 [tasks.tests]
 command = "cargo"
@@ -54,6 +57,41 @@ args = [
     "--exclude",
     "aurora-forwarder-factory"
 ]
+
+[tasks.optimize-contracts]
+dependencies = ["download-wasm-opt"]
+script = '''
+   filesize_before=$(wc -c res/${FWD_WASM_FILE} | awk '{print $1}')
+   res/binaryen/bin/wasm-opt -O4 res/${FWD_WASM_FILE} -o res/${FWD_WASM_FILE} --strip-debug --vacuum
+   filesize_after=$(wc -c res/${FWD_WASM_FILE} | awk '{print $1}')
+   echo "File size before: [$filesize_before] and after: [$filesize_after]"
+ '''
+
+[tasks.download-wasm-opt]
+linux_alias = "download-wasm-opt-linux"
+mac_alias = "download-wasm-opt-macos"
+
+[tasks.download-wasm-opt-macos]
+script = '''
+if [[ ! -f res/binaryen/bin/wasm-opt ]]; then
+   mkdir -p res/binaryen
+   curl -sL https://github.com/WebAssembly/binaryen/releases/download/version_117/binaryen-version_117-arm64-macos.tar.gz | tar -xz -C res/binaryen
+   mv res/binaryen/binaryen-version_117/bin res/binaryen
+   mv res/binaryen/binaryen-version_117/lib res/binaryen
+   rm -rf mv res/binaryen/binaryen-version_117
+fi
+'''
+
+[tasks.download-wasm-opt-linux]
+script = '''
+if [[ ! -f res/binaryen/bin/wasm-opt ]]; then
+   mkdir -p res/binaryen
+   curl -sL https://github.com/WebAssembly/binaryen/releases/download/version_117/binaryen-version_117-x86_64-linux.tar.gz | tar -xz -C res/binaryen
+   mv res/binaryen/binaryen-version_117/bin res/binaryen
+   mv res/binaryen/binaryen-version_117/lib res/binaryen
+   rm -rf mv res/binaryen/binaryen-version_117
+fi
+'''
 
 [tasks.build-factory]
 command = "cargo"
@@ -81,10 +119,10 @@ cp target/${TARGET}/release/aurora_forwarder_factory.wasm res/${FWD_FACTORY_WASM
 [tasks.clean]
 dependencies = ["rm-contracts"]
 command = "cargo"
-args = [ "clean" ]
+args = ["clean"]
 
 [tasks.rm-contracts]
-script = "rm -rf res/${FWD_WASM_FILE} res/${FEES_WASM_FILE} res/${FWD_FACTORY_WASM_FILE}"
+script = "rm -rf res/${FWD_WASM_FILE} res/${FEES_WASM_FILE} res/${FWD_FACTORY_WASM_FILE} res/binaryen"
 
 [tasks.contract-stats]
 category = "Tools"

--- a/factory/src/lib.rs
+++ b/factory/src/lib.rs
@@ -6,7 +6,7 @@ use near_sdk::{
 };
 
 const FORWARDER_WASM: &[u8] = include_bytes!("../../res/aurora-forwarder.wasm");
-const INIT_BALANCE: Balance = 1_800_000_000_000_000_000_000_000;
+const INIT_BALANCE: Balance = 1_530_000_000_000_000_000_000_000;
 const STORAGE_BALANCE_BOUND: Balance = 1_250_000_000_000_000_000_000;
 const FORWARDER_NEW_GAS: Gas = Gas(1_000_000_000_000);
 const MAX_NUM_CONTRACTS: usize = 8;

--- a/forwarder/src/lib.rs
+++ b/forwarder/src/lib.rs
@@ -7,7 +7,7 @@ use near_sdk::{
 };
 use std::str::FromStr;
 
-const MINIMUM_BALANCE: Balance = 1_800_000_000_000_000_000_000_000;
+const MINIMUM_BALANCE: Balance = 1_530_000_000_000_000_000_000_000;
 const MAX_FEE_PERCENT: u128 = 10;
 
 const CALCULATE_FEES_GAS: Gas = Gas(5_000_000_000_000);

--- a/tests/src/tests/mod.rs
+++ b/tests/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod wrap;
 const RECEIVER: &str = "0x17ffdf6becbbc34d5c7d3bf4a0ed4a680395d057";
 const TOTAL_SUPPLY: u128 = 1_000_000_000_000_000;
 const MAX_NUM_CONTRACTS: usize = 8;
+const MIN_FWD_BALANCE: NearToken = NearToken::from_millinear(1530);
 
 static WNEAR: Lazy<AccountId> = Lazy::new(|| "wrap.test.near".parse().unwrap());
 
@@ -225,7 +226,7 @@ async fn test_using_factory() {
     assert_eq!(forwarder_ids.len(), MAX_NUM_CONTRACTS);
 
     for (id, params) in forwarder_ids.iter().zip(parameters) {
-        assert!(sandbox.balance(id).await > NearToken::from_millinear(1800).as_yoctonear());
+        assert!(sandbox.balance(id).await > MIN_FWD_BALANCE.as_yoctonear());
 
         let expected_id = format!(
             "{}.{factory_id}",

--- a/tests/src/tests/native.rs
+++ b/tests/src/tests/native.rs
@@ -2,6 +2,7 @@ use crate::sandbox::aurora::Aurora;
 use crate::sandbox::factory::Factory;
 use crate::sandbox::fungible_token::FungibleToken;
 use crate::sandbox::Sandbox;
+use crate::tests::MIN_FWD_BALANCE;
 use aurora_forwarder_factory::DeployParameters;
 use near_workspaces::types::NearToken;
 use near_workspaces::AccountId;
@@ -44,7 +45,7 @@ async fn test_forward_native_tokens() {
     assert_eq!(
         fwd_balance / rounder,
         transfer
-            .checked_add(NearToken::from_millinear(1800))
+            .checked_add(MIN_FWD_BALANCE)
             .unwrap()
             .as_yoctonear()
             / rounder
@@ -53,7 +54,7 @@ async fn test_forward_native_tokens() {
     factory.forward(&forwarder, &NEAR).await.unwrap();
 
     let fwd_balance = sandbox.balance(&forwarder).await;
-    assert_eq!(fwd_balance / rounder, 1800);
+    assert_eq!(fwd_balance / rounder, MIN_FWD_BALANCE.as_millinear());
 
     let fee = transfer.as_yoctonear() * 5 / 100;
     let deposit = transfer.as_yoctonear() - fee;
@@ -103,7 +104,7 @@ async fn test_forward_native_tokens_with_zero_fee() {
     assert_eq!(
         fwd_balance / rounder,
         transfer
-            .checked_add(NearToken::from_millinear(1800))
+            .checked_add(MIN_FWD_BALANCE)
             .unwrap()
             .as_yoctonear()
             / rounder
@@ -112,7 +113,7 @@ async fn test_forward_native_tokens_with_zero_fee() {
     factory.forward(&forwarder, &NEAR).await.unwrap();
 
     let fwd_balance = sandbox.balance(&forwarder).await;
-    assert_eq!(fwd_balance / rounder, 1800);
+    assert_eq!(fwd_balance / rounder, MIN_FWD_BALANCE.as_millinear());
 
     let deposit = transfer.as_yoctonear();
 


### PR DESCRIPTION
Applying the `wasm-opt` utility decreases the size of the `aurora-forwarder.wasm` contract from 173231 to 152162 bytes. This, in turn, could decrease the required balance for the forwarder account from 1.8 to 1.53 N.